### PR TITLE
[codex] add GH_TOKEN-based worktree automation setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,29 @@
 
 Open `http://127.0.0.1:4173`.
 
+## Automation Setup
+
+One-time GitHub auth setup for worktree automations:
+
+`powershell -ExecutionPolicy Bypass -File C:\Users\AlexFord\.codex\automations\setup-proc-racer-automation-gh.ps1`
+
+This prompts for a GitHub token and stores it as the user environment variable `GH_TOKEN` for future Codex sessions.
+
+Worktree automations should then bootstrap from the worktree itself:
+
+`powershell -ExecutionPolicy Bypass -File scripts/codex-automation-setup.ps1 -RequireGh`
+
+This script:
+
+- installs dependencies when `node_modules/` is missing or stale for that worktree
+- requires `GH_TOKEN` or `GITHUB_TOKEN` to already be present in the environment
+
+Interactive `gh` keyring auth is not enough for background worktree automations. They should use an environment variable instead.
+
+Cleanup command if you want to remove the automation token later:
+
+`powershell -ExecutionPolicy Bypass -File C:\Users\AlexFord\.codex\automations\cleanup-proc-racer-automation-gh.ps1`
+
 ## Validation
 
 `npm run validate`

--- a/scripts/codex-automation-setup.ps1
+++ b/scripts/codex-automation-setup.ps1
@@ -1,0 +1,81 @@
+param(
+  [switch]$SkipInstallDeps,
+  [switch]$RequireGh
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+  $root = git rev-parse --show-toplevel 2>$null
+  if (-not $root) {
+    throw "Not inside a git worktree."
+  }
+
+  return $root.Trim()
+}
+
+function Set-GhAutomationEnv {
+  if ($env:GH_TOKEN -or $env:GITHUB_TOKEN) {
+    return
+  }
+
+  $sharedGhConfig = Join-Path $HOME ".codex\gh-cli"
+  $hostsPath = Join-Path $sharedGhConfig "hosts.yml"
+  if (Test-Path $hostsPath) {
+    $env:GH_CONFIG_DIR = $sharedGhConfig
+    return
+  }
+
+  if ($RequireGh) {
+    throw "GitHub CLI auth is not configured for automations. Expected $hostsPath."
+  }
+}
+
+function Install-RepoDependencies {
+  param(
+    [string]$RepoRoot
+  )
+
+  $packageJson = Join-Path $RepoRoot "package.json"
+  $lockFile = Join-Path $RepoRoot "package-lock.json"
+  $nodeModules = Join-Path $RepoRoot "node_modules"
+
+  if (-not (Test-Path $packageJson) -or -not (Test-Path $lockFile)) {
+    return
+  }
+
+  $needsInstall = -not (Test-Path $nodeModules)
+  if (-not $needsInstall) {
+    $lockTime = (Get-Item $lockFile).LastWriteTimeUtc
+    $modulesTime = (Get-Item $nodeModules).LastWriteTimeUtc
+    $needsInstall = $lockTime -gt $modulesTime
+  }
+
+  if ($needsInstall) {
+    Push-Location $RepoRoot
+    try {
+      npm install
+    } finally {
+      Pop-Location
+    }
+  }
+}
+
+$repoRoot = Get-RepoRoot
+Set-GhAutomationEnv
+
+if (-not $SkipInstallDeps) {
+  Install-RepoDependencies -RepoRoot $repoRoot
+}
+
+Write-Output "RepoRoot=$repoRoot"
+if ($env:GH_TOKEN) {
+  Write-Output "GitHubAuth=GH_TOKEN"
+} elseif ($env:GITHUB_TOKEN) {
+  Write-Output "GitHubAuth=GITHUB_TOKEN"
+} elseif ($env:GH_CONFIG_DIR) {
+  Write-Output "GitHubAuth=GH_CONFIG_DIR"
+  Write-Output "GH_CONFIG_DIR=$($env:GH_CONFIG_DIR)"
+} else {
+  Write-Output "GitHubAuth=Unavailable"
+}


### PR DESCRIPTION
## Summary

- add a repo-local bootstrap script for worktree automations
- document the GH_TOKEN-based setup flow for background automation runs
- keep GitHub CLI auth for automations environment-based instead of relying on interactive keyring lookup

## Problem

Codex automations run in worktrees and background sessions, which can resolve the repository correctly but still fail to use gh when auth only exists in an interactive keyring-backed session. The repo also had no explicit bootstrap step for worktree runs.

## Fix

This change adds scripts/codex-automation-setup.ps1, which resolves the active worktree root, installs dependencies only when needed, and reports whether GH_TOKEN or GITHUB_TOKEN is available for the current session. It also documents the intended setup in CONTRIBUTING.md so automation runs have a repeatable bootstrap step.

## Validation

- powershell -ExecutionPolicy Bypass -File scripts/codex-automation-setup.ps1 -SkipInstallDeps
- GH_TOKEN=<token> npm run issues:auth equivalent verified in PowerShell by setting $env:GH_TOKEN before running 
pm run issues:auth

## Notes

- local .codex/ automation files are intentionally not part of this PR
- this PR only adds the repo-side bootstrap/documentation needed to support the local automation configuration
