### PR TITLE
[codex] make issue label sync idempotent

### DIFF
--- a/scripts/codex-issues.mjs
+++ b/scripts/codex-issues.mjs
@@ -496,13 +496,14 @@ async function ensureLabels(parsed) {
       "label",
       "create",
       label.name,
+      "--force",
       "--color",
       label.color,
       "--description",
       label.description,
       ...getRepoArgs(parsed),
     ]);
-    console.log(`Created label ${label.name}`);
+    console.log(`Ensured label ${label.name}`);
   }
 }
 


### PR DESCRIPTION
## Summary

The automation backlog triage flow was failing during `npm run issues:labels` when the repository already had one of the required labels. That meant the setup step was not idempotent: a partially configured repo could cause later automation runs to stop before backlog review or issue creation even started.

The root cause was in `scripts/codex-issues.mjs`. The `labels` command fetched existing labels, identified missing ones, and then used `gh label create` for each candidate. In practice the GitHub API can still report an existing label conflict during this flow, and the script treated that as a hard failure.

This change makes label enforcement idempotent by passing `--force` to `gh label create` and by logging `Ensured label ...` instead of `Created label ...`. The effect is that repeated automation runs can safely normalize label metadata instead of failing on an already-existing label.

## Validation

- Ran `npm run issues:labels`
- Confirmed the command completed successfully against the live repo and ensured the required labels instead of erroring on an existing one
