### PR TITLE
[codex] #16 Add live cosmetic previews before buying or equipping style items

### DIFF
--- a/src/core/styleLocker.js
+++ b/src/core/styleLocker.js
@@ -57,17 +57,20 @@ export function equipCosmetic(save, itemId) {
   return { ok: true, item };
 }
 
-export function getEquippedCosmeticDefs(save) {
+export function getEquippedCosmeticDefs(save, cosmeticOverrides = null) {
   ensureStyleLocker(save);
+  const defaults = createDefaultEquippedCosmetics();
   return COSMETIC_SLOTS.reduce((acc, slot) => {
-    const itemId = save.equippedCosmetics?.[slot];
-    acc[slot] = COSMETIC_DEFS[itemId] || COSMETIC_DEFS[createDefaultEquippedCosmetics()[slot]];
+    const overrideId = typeof cosmeticOverrides?.[slot] === "string" ? cosmeticOverrides[slot] : null;
+    const itemId = overrideId || save.equippedCosmetics?.[slot];
+    const resolved = COSMETIC_DEFS[itemId];
+    acc[slot] = resolved?.slot === slot ? resolved : COSMETIC_DEFS[defaults[slot]];
     return acc;
   }, {});
 }
 
-export function getGarageCarStyle(save, car) {
-  const cosmetics = getEquippedCosmeticDefs(save);
+export function getGarageCarStyle(save, car, cosmeticOverrides = null) {
+  const cosmetics = getEquippedCosmeticDefs(save, cosmeticOverrides);
   const skin = cosmetics.skin;
   const trail = cosmetics.trail;
   const skid = cosmetics.skid;

--- a/src/core/ui/index.js
+++ b/src/core/ui/index.js
@@ -33,6 +33,7 @@ import {
 } from "./routes.js";
 import { getRouteSection, getSectionOptions, setRouteSection as assignRouteSection } from "./sections.js";
 import { renderActiveScreen, renderOverlays, renderShell } from "./screens.js";
+import { renderStylePreviewCards } from "./renderers/style.js";
 
 function createRefs() {
   return {
@@ -252,6 +253,7 @@ export function createUi(state, callbacks = {}) {
 
   function setRouteScreen(screen) {
     const nextScreen = normalizeMenuScreen(screen);
+    if (nextScreen !== "style") route.stylePreviewItemId = null;
     route.stage = "hub";
     route.screen = nextScreen;
     assignRouteSection(route, nextScreen, getRouteSection(route, nextScreen));
@@ -263,6 +265,7 @@ export function createUi(state, callbacks = {}) {
 
   function setRouteSection(section) {
     const nextSection = assignRouteSection(route, route.screen, section);
+    if (route.screen === "style") route.stylePreviewItemId = null;
     callbacks.onMenuSectionChange?.(route.screen, nextSection);
     syncMenu();
   }
@@ -596,6 +599,24 @@ export function createUi(state, callbacks = {}) {
     return target instanceof Element ? target.closest(".info-btn[data-tooltip]") : null;
   }
 
+  function closestStyleCard(target) {
+    return target instanceof Element ? target.closest(".style-card[data-style-id]") : null;
+  }
+
+  function updateStylePreview(nextItemId = null) {
+    const normalized = typeof nextItemId === "string" ? nextItemId : null;
+    if (route.stylePreviewItemId === normalized) return;
+    route.stylePreviewItemId = normalized;
+    if (route.screen !== "style") return;
+    const previewHost = getScreenEl("equipped-style");
+    if (!previewHost) return;
+    previewHost.innerHTML = renderStylePreviewCards(deriveScreenModel(state, route));
+    refs.hubScreen.querySelectorAll(".style-card").forEach((card) => {
+      card.classList.toggle("previewing", card.dataset.styleId === route.stylePreviewItemId);
+    });
+    updateMenuScale();
+  }
+
   refs.splashStartBtn?.addEventListener("click", () => callbacks.onEnterGarage?.());
   refs.pauseResume.addEventListener("click", () => callbacks.onPauseResume?.());
   refs.pauseRetry.addEventListener("click", () => callbacks.onPauseRetry?.());
@@ -659,10 +680,12 @@ export function createUi(state, callbacks = {}) {
     if (target.dataset.styleSlot) {
       route.styleSlot = target.dataset.styleSlot;
       route.stylePage = 0;
+      route.stylePreviewItemId = null;
       syncMenu();
     }
     if (target.dataset.stylePageNav) {
       route.stylePage = Math.max(0, (route.stylePage || 0) + Number(target.dataset.stylePageNav));
+      route.stylePreviewItemId = null;
       syncMenu();
     }
     if (target.dataset.styleId && target.dataset.styleAction === "buy") callbacks.onCosmeticBuy?.(target.dataset.styleId);
@@ -675,6 +698,20 @@ export function createUi(state, callbacks = {}) {
   refs.hubScreen.addEventListener("input", (event) => {
     const target = event.target;
     if (target.id === "settings-volume") callbacks.onSettingChange?.("masterVolume", Number(target.value) / 100);
+  });
+  refs.hubScreen.addEventListener("pointerover", (event) => {
+    const card = closestStyleCard(event.target);
+    if (!card) return;
+    const previousCard = closestStyleCard(event.relatedTarget);
+    if (previousCard === card) return;
+    updateStylePreview(card.dataset.styleId);
+  });
+  refs.hubScreen.addEventListener("pointerout", (event) => {
+    const card = closestStyleCard(event.target);
+    if (!card) return;
+    const nextCard = closestStyleCard(event.relatedTarget);
+    if (nextCard === card) return;
+    updateStylePreview(null);
   });
   refs.hubScreen.addEventListener("change", (event) => {
     const target = event.target;
@@ -689,6 +726,17 @@ export function createUi(state, callbacks = {}) {
       event.preventDefault();
       callbacks.onCustomCourseSeedApply?.(event.target.value);
     }
+  });
+  refs.hubScreen.addEventListener("focusin", (event) => {
+    const card = closestStyleCard(event.target);
+    if (card) updateStylePreview(card.dataset.styleId);
+  });
+  refs.hubScreen.addEventListener("focusout", (event) => {
+    const card = closestStyleCard(event.target);
+    if (!card) return;
+    const nextCard = closestStyleCard(event.relatedTarget);
+    if (nextCard === card) return;
+    updateStylePreview(null);
   });
 
   document.addEventListener("pointerenter", (event) => {

--- a/src/core/ui/legacy.js
+++ b/src/core/ui/legacy.js
@@ -407,6 +407,7 @@ function renderCosmeticPreview(item, slotOverride = item?.slot) {
         <div class="style-preview-rig style-preview-rig-drive">
           <div class="style-preview-car">
             <span class="style-preview-car-cabin"></span>
+            <span class="style-preview-car-stripe"></span>
           </div>
         </div>
         <div class="style-preview-trail-line"></div>
@@ -437,8 +438,63 @@ function renderCosmeticPreview(item, slotOverride = item?.slot) {
       <div class="style-preview-rig">
         <div class="style-preview-car">
           <span class="style-preview-car-cabin"></span>
+          <span class="style-preview-car-stripe"></span>
         </div>
       </div>
+    </div>
+  `;
+}
+
+function getStylePreviewSourceLabel(previewItem, activeItem, owned) {
+  if (!previewItem || previewItem.id === activeItem?.id) return "Current loadout";
+  return owned ? "Locker preview" : "Shop preview";
+}
+
+function getStylePreviewStatusCopy(slot, previewItem, activeItem, selectedCar) {
+  const carName = selectedCar?.name || "active car";
+  if (!previewItem || previewItem.id === activeItem?.id) {
+    return `Current ${slot} loadout on ${carName}.`;
+  }
+  if (slot === "emote") {
+    return `Results stinger preview for ${carName} before you commit.`;
+  }
+  return `Previewing ${previewItem.name} on ${carName} before you buy or equip.`;
+}
+
+function renderStyleLivePreview(style, slot, previewItem) {
+  const accent = style?.accentColor || getPreviewAccent(previewItem, slot);
+  const body = style?.bodyColor || accent;
+  const trail = style?.trailColor || accent;
+  const skid = style?.skidColor || "rgba(220, 232, 255, 0.18)";
+  const badge = style?.emoteBadge || previewItem?.badge || "STEEL SET";
+  const previewId = previewItem?.id || `${slot}-live`;
+  if (slot === "emote") {
+    return `
+      <div class="style-preview style-preview-live" data-slot="emote" data-preview-id="${previewId}" style="--preview-accent:${accent};--preview-body:${body};--preview-trail:${trail};--preview-skid:${skid};">
+        <div class="style-preview-emote-wrap">
+          <div class="style-preview-emote">${badge}</div>
+        </div>
+        <div class="style-preview-results-mark">RESULTS STINGER LIVE</div>
+      </div>
+    `;
+  }
+  return `
+    <div class="style-preview style-preview-live" data-slot="${slot}" data-preview-id="${previewId}" style="--preview-accent:${accent};--preview-body:${body};--preview-trail:${trail};--preview-skid:${skid};">
+      <div class="style-preview-rig${slot === "trail" ? " style-preview-rig-drive" : ""}">
+        <div class="style-preview-car">
+          <span class="style-preview-car-cabin"></span>
+          <span class="style-preview-car-stripe"></span>
+        </div>
+      </div>
+      ${slot === "trail" ? `
+        <div class="style-preview-trail-line"></div>
+        <div class="style-preview-trail-line style-preview-trail-line-b"></div>
+      ` : ""}
+      ${slot === "skid" ? `
+        <div class="style-preview-skid-line"></div>
+        <div class="style-preview-skid-line style-preview-skid-line-b"></div>
+        <div class="style-preview-skid-spark"></div>
+      ` : ""}
     </div>
   `;
 }
@@ -2396,12 +2452,15 @@ export {
   getSelectedGarageCar,
   getStartLabel,
   getStoredMedal,
+  getStylePreviewSourceLabel,
+  getStylePreviewStatusCopy,
   getStylePageSize,
   isStarterCosmetic,
   medalForResult,
   medalRank,
   normalizeCourseSeed,
   renderCosmeticPreview,
+  renderStyleLivePreview,
   renderStatTiles,
   supportsCustomCourseSeed,
 };

--- a/src/core/ui/models/style.js
+++ b/src/core/ui/models/style.js
@@ -1,7 +1,12 @@
 import { getCurrencyBalance } from "../../economy.js";
-import { ensureStyleLocker, getEquippedCosmeticDefs, isCosmeticOwned } from "../../styleLocker.js";
+import { ensureStyleLocker, getEquippedCosmeticDefs, getGarageCarStyle, isCosmeticOwned } from "../../styleLocker.js";
 import { COSMETIC_SLOTS, getCosmeticsBySlot } from "../../../data/cosmetics.js";
-import { getStylePageSize } from "../legacy.js";
+import {
+  getSelectedGarageCar,
+  getStylePageSize,
+  getStylePreviewSourceLabel,
+  getStylePreviewStatusCopy,
+} from "../legacy.js";
 
 function clampPage(page, pageCount) {
   return Math.max(0, Math.min(pageCount - 1, Number.isInteger(page) ? page : 0));
@@ -17,21 +22,37 @@ export function buildStyleModel(state, route) {
   const visibleItems = slotItems.slice(page * pageSize, (page + 1) * pageSize);
   const equipped = getEquippedCosmeticDefs(state.save);
   const activeStyleItem = equipped[activeSlot] || null;
+  const selectedCar = getSelectedGarageCar(state);
+  const previewCandidate = slotItems.find((item) => item.id === route.stylePreviewItemId) || null;
+  const previewItem = previewCandidate?.slot === activeSlot ? previewCandidate : activeStyleItem;
+  const previewOwned = previewItem ? isCosmeticOwned(state.save, previewItem.id) : false;
+  const previewStyle = selectedCar
+    ? getGarageCarStyle(state.save, selectedCar, previewItem ? { [activeSlot]: previewItem.id } : null)
+    : null;
   return {
     type: "style",
     scrap: getCurrencyBalance(state.save, "scrap"),
     activeSlot,
     page,
     pageCount,
+    slotCount: slotItems.length,
     slots: COSMETIC_SLOTS,
     equippedItem: activeStyleItem,
+    preview: {
+      item: previewItem,
+      owned: previewOwned,
+      style: previewStyle,
+      carName: selectedCar?.name || "No active car",
+      sourceLabel: getStylePreviewSourceLabel(previewItem, activeStyleItem, previewOwned),
+      statusCopy: getStylePreviewStatusCopy(activeSlot, previewItem, activeStyleItem, selectedCar),
+    },
     visibleItems: visibleItems.map((item) => {
       const owned = isCosmeticOwned(state.save, item.id);
-      const equippedItemId = state.save.equippedCosmetics?.[activeSlot];
-      const selected = equippedItemId === item.id;
+      const selected = activeStyleItem?.id === item.id;
       return {
         ...item,
         owned,
+        previewing: route.stylePreviewItemId === item.id,
         selected,
         action: owned ? "equip" : "buy",
         actionLabel: selected ? "Equipped" : owned ? "Equip" : `Buy ${item.cost} Scrap`,

--- a/src/core/ui/renderers/style.js
+++ b/src/core/ui/renderers/style.js
@@ -1,10 +1,37 @@
-import { renderCosmeticPreview } from "../legacy.js";
+import { isStarterCosmetic, renderCosmeticPreview, renderStyleLivePreview } from "../legacy.js";
 import { renderInfoButton } from "../render-helpers.js";
 
 function renderStyleSlotTabs(model) {
   return `
     <div id="style-slot-tabs" class="style-slot-tabs">
       ${model.slots.map((slot) => `<button class="menu-tab${model.activeSlot === slot ? " selected" : ""}" data-style-slot="${slot}" type="button">${slot}</button>`).join("")}
+    </div>
+  `;
+}
+
+export function renderStylePreviewCards(model) {
+  return `
+    <div class="garage-item style-live-card">
+      ${renderStyleLivePreview(model.preview.style, model.activeSlot, model.preview.item)}
+      <div class="section-label">Live preview</div>
+      <div class="profile-value">${model.preview.item?.name || "None"}</div>
+      <div class="profile-note">${model.preview.statusCopy}</div>
+      <div class="mini-tags">
+        <span class="mini-tag">${model.preview.sourceLabel}</span>
+        <span class="mini-tag">${model.preview.carName}</span>
+        <span class="mini-tag">${model.preview.owned ? "Owned or starter" : `${model.preview.item?.cost || 0} Scrap`}</span>
+      </div>
+    </div>
+    <div class="garage-item style-equipped-card">
+      ${renderCosmeticPreview(model.equippedItem, model.activeSlot)}
+      <div class="section-label">${model.activeSlot} loadout</div>
+      <div class="profile-value">${model.equippedItem?.name || "None"}</div>
+      <div class="profile-note">${model.equippedItem?.description || "No cosmetic equipped for this slot."}</div>
+      <div class="mini-tags">
+        <span class="mini-tag">${isStarterCosmetic(model.equippedItem) ? "Starter issue" : "Locker owned"}</span>
+        <span class="mini-tag">Equipped</span>
+        <span class="mini-tag">${model.slotCount} options</span>
+      </div>
     </div>
   `;
 }
@@ -21,12 +48,7 @@ function renderStyleLoadout(model) {
       </div>
       ${renderStyleSlotTabs(model)}
       <div id="equipped-style" class="style-equipped workspace-style-loadout-card">
-        <div class="garage-item style-equipped-card">
-          ${renderCosmeticPreview(model.equippedItem, model.activeSlot)}
-          <div class="section-label">${model.activeSlot} loadout</div>
-          <div class="profile-value">${model.equippedItem?.name || "None"}</div>
-          <div class="profile-note">${model.equippedItem?.description || "No cosmetic equipped for this slot."}</div>
-        </div>
+        ${renderStylePreviewCards(model)}
       </div>
     </section>
   `;
@@ -43,7 +65,10 @@ function renderStyleShop(model) {
         <div id="scrap-currency" class="section-note">${model.scrap} Scrap</div>
       </div>
       ${renderStyleSlotTabs(model)}
-      <div id="style-shop" class="style-shop">
+      <div id="style-shop" class="style-shop workspace-style-grid">
+        <div id="equipped-style" class="style-equipped workspace-style-loadout-card">
+          ${renderStylePreviewCards(model)}
+        </div>
         <div class="style-slot-group">
           <div class="section-head style-slot-head">
             <div class="section-head-main">
@@ -57,16 +82,17 @@ function renderStyleShop(model) {
           </div>
           <div class="style-card-grid">
             ${model.visibleItems.map((item) => `
-              <button class="style-card${item.selected ? " selected" : ""}" data-style-id="${item.id}" data-style-action="${item.action}" ${item.selected ? "disabled" : ""} type="button">
+              <button class="style-card${item.selected ? " selected" : ""}${item.previewing ? " previewing" : ""}" data-style-id="${item.id}" data-style-action="${item.action}" ${item.selected ? "disabled" : ""} type="button">
                 ${renderCosmeticPreview(item, model.activeSlot)}
                 <div class="card-head">
                   <div class="card-title">${item.name}</div>
-                  <div class="card-kicker">${item.owned ? "Owned" : "Shop"}</div>
+                  <div class="card-kicker">${item.previewing ? "Preview live" : item.selected ? "Equipped" : item.owned ? "Owned" : "Shop"}</div>
                 </div>
                 <div class="card-meta">${item.description}</div>
                 <div class="mini-tags">
                   <span class="mini-tag">${item.owned ? "Owned" : `${item.cost} Scrap`}</span>
-                  ${item.selected ? '<span class="mini-tag">Live</span>' : ""}
+                  ${item.selected ? '<span class="mini-tag">Equipped</span>' : ""}
+                  ${item.previewing ? '<span class="mini-tag">Previewing</span>' : ""}
                 </div>
                 <div class="style-card-action">${item.actionLabel}</div>
               </button>

--- a/src/core/ui/routes.js
+++ b/src/core/ui/routes.js
@@ -55,6 +55,7 @@ export function createRouteState(state) {
     boardPage: null,
     styleSlot: "skin",
     stylePage: 0,
+    stylePreviewItemId: null,
     resultsPane: "summary",
   };
 }

--- a/style.css
+++ b/style.css
@@ -3227,6 +3227,11 @@ body[data-contrast="high"]::before {
   box-shadow: 0 0 24px rgba(255, 31, 209, 0.12);
 }
 
+.style-card.previewing {
+  border-color: rgba(141, 247, 255, 0.38);
+  box-shadow: 0 0 28px rgba(141, 247, 255, 0.12);
+}
+
 .style-card[disabled] {
   cursor: default;
   opacity: 0.74;
@@ -3246,6 +3251,16 @@ body[data-contrast="high"]::before {
   display: grid;
   gap: 8px;
   align-content: start;
+}
+
+.style-live-card {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  padding-bottom: 12px;
+  background:
+    linear-gradient(160deg, rgba(12, 19, 37, 0.96), rgba(8, 13, 25, 0.9)),
+    radial-gradient(circle at top right, rgba(255, 31, 209, 0.12), transparent 34%);
 }
 
 .style-equipped-card .profile-note {
@@ -3314,7 +3329,7 @@ body[data-contrast="high"]::before {
   height: 42px;
   border-radius: 18px 24px 14px 14px;
   transform: translate(-50%, -50%);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--preview-accent) 56%, #122446), #0b1223 78%);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--preview-body, var(--preview-accent)) 72%, #122446), #0b1223 78%);
   box-shadow:
     0 0 20px color-mix(in srgb, var(--preview-accent) 24%, transparent),
     inset 0 -10px 18px rgba(0, 0, 0, 0.28);
@@ -3350,6 +3365,17 @@ body[data-contrast="high"]::before {
   background: rgba(227, 245, 255, 0.4);
 }
 
+.style-preview-car-stripe {
+  position: absolute;
+  left: 18px;
+  right: 16px;
+  bottom: 9px;
+  height: 7px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--preview-accent) 58%, white 8%), transparent 94%);
+  opacity: 0.82;
+}
+
 .style-preview[data-slot="trail"] .style-preview-car {
   width: 74px;
   height: 30px;
@@ -3363,7 +3389,7 @@ body[data-contrast="high"]::before {
   top: 50%;
   height: 8px;
   transform: translateY(-50%);
-  background: linear-gradient(90deg, color-mix(in srgb, var(--preview-accent) 72%, white 20%), transparent 88%);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--preview-trail, var(--preview-accent)) 72%, white 20%), transparent 88%);
   filter: blur(0.8px);
   transform-origin: left center;
   animation: styleTrailPulse 1.9s ease-in-out infinite;
@@ -3384,7 +3410,7 @@ body[data-contrast="high"]::before {
   right: 16%;
   height: 6px;
   top: 40%;
-  background: linear-gradient(90deg, transparent, var(--preview-accent) 30%, transparent 88%);
+  background: linear-gradient(90deg, transparent, var(--preview-skid, var(--preview-accent)) 30%, transparent 88%);
   opacity: 0.9;
   transform: rotate(-7deg);
   animation: styleSkidSweep 2.1s ease-in-out infinite;
@@ -3403,10 +3429,85 @@ body[data-contrast="high"]::before {
   width: 18px;
   height: 18px;
   background:
-    radial-gradient(circle, color-mix(in srgb, var(--preview-accent) 88%, white 10%) 0 26%, transparent 28%),
-    radial-gradient(circle, color-mix(in srgb, var(--preview-accent) 60%, #ffb100 20%) 0 16%, transparent 18%);
+    radial-gradient(circle, color-mix(in srgb, var(--preview-skid, var(--preview-accent)) 88%, white 10%) 0 26%, transparent 28%),
+    radial-gradient(circle, color-mix(in srgb, var(--preview-skid, var(--preview-accent)) 60%, #ffb100 20%) 0 16%, transparent 18%);
   filter: blur(0.4px);
   animation: styleSparkPulse 1.5s ease-in-out infinite;
+}
+
+.style-preview-live {
+  min-height: 156px;
+  border-color: rgba(141, 247, 255, 0.18);
+  box-shadow:
+    inset 0 0 0 1px rgba(141, 247, 255, 0.06),
+    0 0 30px rgba(141, 247, 255, 0.06);
+}
+
+.style-preview-live .style-preview-car {
+  width: 126px;
+  height: 54px;
+}
+
+.style-preview-live[data-slot="trail"] .style-preview-car,
+.style-preview-live[data-slot="skid"] .style-preview-car {
+  width: 108px;
+  height: 44px;
+  left: 44%;
+}
+
+.style-preview-live .style-preview-car-cabin {
+  left: 30px;
+  top: 10px;
+  width: 44px;
+  height: 16px;
+}
+
+.style-preview-live .style-preview-car-stripe {
+  left: 22px;
+  right: 20px;
+  bottom: 11px;
+  height: 8px;
+}
+
+.style-preview-live .style-preview-trail-line {
+  left: 48%;
+  right: 10%;
+  height: 10px;
+}
+
+.style-preview-live .style-preview-trail-line-b {
+  left: 50%;
+  right: 16%;
+  height: 6px;
+}
+
+.style-preview-live .style-preview-skid-line {
+  left: 16%;
+  right: 12%;
+  height: 7px;
+}
+
+.style-preview-live .style-preview-skid-line-b {
+  transform: rotate(-7deg) translateX(18px);
+}
+
+.style-preview-live .style-preview-skid-spark {
+  right: 20%;
+  width: 20px;
+  height: 20px;
+}
+
+.style-preview-results-mark {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 14px;
+  color: rgba(227, 245, 255, 0.72);
+  font-family: "Orbitron", sans-serif;
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-align: center;
 }
 
 .style-preview-emote-wrap {


### PR DESCRIPTION
## Summary
- add temporary style-loadout overrides so the UI can preview one slot without mutating the save
- add a live style preview panel that updates on hover/focus for shop and owned cosmetics
- tune the style preview visuals so body tint, accent stripe, trail, skid, and emote states reflect the active rig

## Linked Issue
- Closes #16

## Validation
- npm run validate (seed/content phase passed; browser Playwright phase blocked here with `browserType.launch: spawn EPERM`)
- npm run validate:content
- node --input-type=module -e "await import('./src/core/styleLocker.js'); await import('./src/core/ui.js'); console.log('module-smoke-ok');"
