### PR TITLE
[codex] expand unit coverage and fix progression regressions

### DIFF
--- a/src/core/gameplay.js
+++ b/src/core/gameplay.js
@@ -1,6 +1,7 @@
 import { AI_PROFILE_DEFS, CAR_DEFS, PICKUP_DEFS } from "../data/content.js";
 import { getControlBinding } from "./controls.js";
 import { getSectorAtProgress, nearestPathInfo, samplePath, sampleTrackBank, sampleTrackHeight } from "./generator.js";
+import { getCarRaceUnits } from "./raceProgress.js";
 import { clamp, distance, normalize, wrapAngle } from "./utils.js";
 
 const DEFAULT_PARTS = ["bumper", "door", "spoiler", "panel"];
@@ -45,8 +46,7 @@ function getAssistConfig(state) {
 }
 
 function getRaceScore(state, car) {
-  const checkpointCount = state.track?.checkpoints?.length || 10;
-  return (car.currentLap - 1) * checkpointCount + car.checkpointIndex + (car.progress || 0);
+  return getCarRaceUnits(state, car);
 }
 
 function getRelativeTrackProgress(track, rawT) {

--- a/src/core/raceProgress.js
+++ b/src/core/raceProgress.js
@@ -1,0 +1,30 @@
+import { clamp } from "./utils.js";
+
+function getCheckpointCount(track) {
+  return Math.max(1, track?.checkpoints?.length || 1);
+}
+
+function getProgressUnitScale(track) {
+  const checkpointCount = getCheckpointCount(track);
+  return track?.type === "sprint" ? Math.max(1, checkpointCount - 1) : checkpointCount;
+}
+
+function getNormalizedProgress(progress) {
+  return clamp(Number.isFinite(progress) ? progress : 0, 0, 1);
+}
+
+export function getTrackRaceUnits(state) {
+  const unitScale = getProgressUnitScale(state.track);
+  return state.track?.type === "circuit"
+    ? Math.max(1, (state.currentEvent?.laps || 1) * unitScale)
+    : unitScale;
+}
+
+export function getCarRaceUnits(state, car) {
+  const unitScale = getProgressUnitScale(state.track);
+  const progressUnits = getNormalizedProgress(car.progress) * unitScale;
+  if (state.track?.type === "circuit") {
+    return Math.max(0, (Math.max(1, car.currentLap) - 1) * unitScale + progressUnits);
+  }
+  return Math.max(0, progressUnits);
+}

--- a/src/core/ui/legacy.js
+++ b/src/core/ui/legacy.js
@@ -13,6 +13,7 @@ import {
 } from "../garage.js";
 import { CONTROL_DEFAULTS, CONTROL_LABELS } from "../controls.js";
 import { COURSE_REROLL_COST, getCurrencyBalance } from "../economy.js";
+import { getCarRaceUnits, getTrackRaceUnits } from "../raceProgress.js";
 import { ensureStyleLocker, getEquippedCosmeticDefs, isCosmeticOwned } from "../styleLocker.js";
 import { createKey, formatTime } from "../utils.js";
 import { BIOME_DEFS, MODIFIER_DEFS, PICKUP_DEFS } from "../../data/content.js";
@@ -265,22 +266,6 @@ function getDisplayEvent(state, event) {
     customSeedValue: customSeed,
     customSeedMatchesBoard: false,
   };
-}
-
-function getTrackRaceUnits(state) {
-  const checkpointCount = Math.max(1, state.track?.checkpoints?.length || 1);
-  return state.track?.type === "circuit"
-    ? Math.max(1, (state.currentEvent?.laps || 1) * checkpointCount)
-    : Math.max(1, checkpointCount - 1);
-}
-
-function getCarRaceUnits(state, car) {
-  const checkpointCount = Math.max(1, state.track?.checkpoints?.length || 1);
-  const progress = Number.isFinite(car.progress) ? car.progress : 0;
-  if (state.track?.type === "circuit") {
-    return Math.max(0, (Math.max(1, car.currentLap) - 1) * checkpointCount + car.checkpointIndex + progress);
-  }
-  return Math.max(0, car.checkpointIndex + progress);
 }
 
 function getClassifiedFinishTime(state, car, totalUnits, secondsPerUnit) {

--- a/src/main.js
+++ b/src/main.js
@@ -295,6 +295,16 @@ function enterGarage() {
   }, 90);
 }
 
+function getLastStrikeBoardEventIndex() {
+  const dailyIndex = state.events.findIndex((event) => event.daily);
+  const lastBoardIndex = dailyIndex > 1 ? dailyIndex - 1 : state.events.length - 1;
+  return Math.max(1, lastBoardIndex);
+}
+
+function getSavedHubEventIndex(eventProgress = state.save.eventProgress) {
+  return clamp(eventProgress || 1, 1, getLastStrikeBoardEventIndex());
+}
+
 function createEvents() {
   const strikeBoard = ensureStrikeBoardState();
   ensureCustomCourseSeedState();
@@ -312,7 +322,7 @@ function createEvents() {
   }
   state.events = [...buildStrikeBoardEvents(strikeBoard.seed), dailyEvent];
   if (!state.save.settings.tutorialCompleted) state.selectedEventIndex = 0;
-  else state.selectedEventIndex = clamp(state.save.eventProgress || 1, 1, state.events.length - 1);
+  else state.selectedEventIndex = getSavedHubEventIndex();
   syncSelectedGarageCar();
 }
 
@@ -331,7 +341,7 @@ function hydrateRunSummary(result) {
   }
   if (result.place === 1) {
     state.save.wins += 1;
-    state.save.eventProgress = Math.max(state.save.eventProgress, state.selectedEventIndex + 1);
+    state.save.eventProgress = getSavedHubEventIndex(Math.max(state.save.eventProgress, state.selectedEventIndex + 1));
   }
   if (result.event.guided && result.tutorialPickupMet) state.save.settings.tutorialCompleted = true;
   const bestKey = createKey(result.eventId, result.carId);
@@ -503,7 +513,7 @@ function rerollStrikeBoard() {
   if (previousEvent?.daily) state.selectedEventIndex = state.events.findIndex((event) => event.daily);
   else if (previousEvent?.guided) state.selectedEventIndex = 0;
   else if (!state.save.settings.tutorialCompleted) state.selectedEventIndex = 1;
-  else state.selectedEventIndex = clamp(previousIndex, 1, state.events.length - 2);
+  else state.selectedEventIndex = clamp(previousIndex, 1, getLastStrikeBoardEventIndex());
   persistSave(state.save);
   bus.emit("course_refresh", {
     price: purchase.price,
@@ -520,7 +530,7 @@ function retryRace() {
 
 function backToMenu() {
   if (state.currentEvent?.guided && state.save.settings.tutorialCompleted) {
-    state.selectedEventIndex = clamp(state.save.eventProgress || 1, 1, state.events.length - 1);
+    state.selectedEventIndex = getSavedHubEventIndex();
   }
   clearGarageRollTimers();
   state.garageRoll = null;
@@ -549,7 +559,6 @@ function startGarageRoll() {
     revealedSlots: [],
     assignments: {},
   };
-  persistSave(state.save);
   clearGarageRollTimers();
   bus.emit("garage_roll_start", { seed, price: purchase.price });
   const revealMoments = [920, 1380, 1820];

--- a/tests/playwright/validate.spec.mjs
+++ b/tests/playwright/validate.spec.mjs
@@ -130,6 +130,76 @@ test("garage roll and style equip loop holds together @garage", async ({ page })
   expectNoPageErrors(errors);
 });
 
+test("oversized event progress auto-selects the last strike-board event instead of the daily", async ({ page }) => {
+  const errors = attachPageErrorCollector(page);
+  await resetApp(page, { tutorialCompleted: true });
+
+  await page.evaluate(() => {
+    const raw = localStorage.getItem("proc-racer-save-v5");
+    const save = JSON.parse(raw);
+    save.eventProgress = 999;
+    localStorage.setItem("proc-racer-save-v5", JSON.stringify(save));
+  });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(250);
+  await enterHub(page);
+
+  const selection = await page.evaluate(() => {
+    const events = window.__procRacer.events;
+    const selectedEventIndex = window.__procRacer.selectedEventIndex;
+    const selectedEvent = events[selectedEventIndex] || null;
+    const dailyIndex = events.findIndex((event) => event.daily);
+    const lastBoardIndex = dailyIndex - 1;
+    return {
+      selectedEventIndex,
+      selectedEventId: selectedEvent?.id || null,
+      selectedEventDaily: Boolean(selectedEvent?.daily),
+      lastBoardIndex,
+      lastBoardId: events[lastBoardIndex]?.id || null,
+    };
+  });
+
+  expect(selection.selectedEventIndex).toBe(selection.lastBoardIndex);
+  expect(selection.selectedEventId).toBe(selection.lastBoardId);
+  expect(selection.selectedEventDaily).toBe(false);
+
+  expectNoPageErrors(errors);
+});
+
+test("reloading during a garage roll restores the pre-roll save instead of burning Flux", async ({ page }) => {
+  const errors = attachPageErrorCollector(page);
+  await resetApp(page);
+  await enterHub(page);
+  await goToScreen(page, "foundry");
+
+  expect(await page.evaluate(() => window.__procRacer.save.wallet.flux)).toBe(220);
+
+  await page.click("#garage-roll-btn");
+  await expect(page.locator("#garage-roll-modal")).toBeVisible();
+  const spinningState = await page.evaluate(() => ({
+    flux: window.__procRacer.save.wallet.flux,
+    garageRollStatus: window.__procRacer.garageRoll?.status || null,
+  }));
+  expect(spinningState.flux).toBe(40);
+  expect(spinningState.garageRollStatus).toBe("spinning");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(250);
+  await enterHub(page);
+  await goToScreen(page, "foundry");
+
+  const restoredState = await page.evaluate(() => ({
+    flux: window.__procRacer.save.wallet.flux,
+    scrap: window.__procRacer.save.wallet.scrap,
+    garageRoll: window.__procRacer.garageRoll,
+  }));
+  expect(restoredState.flux).toBe(220);
+  expect(restoredState.scrap).toBe(0);
+  expect(restoredState.garageRoll).toBeNull();
+
+  expectNoPageErrors(errors);
+});
+
 test("strike-board reroll mutates the board without touching the daily @reroll", async ({ page }) => {
   const errors = attachPageErrorCollector(page);
   await resetApp(page);

--- a/tests/units/core.test.mjs
+++ b/tests/units/core.test.mjs
@@ -13,7 +13,6 @@ import {
 } from "../../src/core/economy.js";
 
 import {
-  GARAGE_SCRAP_VALUE,
   isGarageSlotFilled, createEmptyGarageSlot,
   getGarageHandling, getGarageScore, getGarageStatPercent,
   getScrapValue, calculateRaceReward, getGarageProgression,
@@ -53,11 +52,16 @@ function makeResult(overrides = {}) {
   };
 }
 
-// Starter car hardcoded stats (from createStarterCar in garage.js).
-const STARTER_STATS = {
-  accel: 372, maxSpeed: 330, turn: 2.28, grip: 6.58, durability: 112,
-  mass: 1.01, brakeTurn: 1.08, slipstreamAffinity: 0.98, tierId: "starter",
-};
+function getStarterCar() {
+  return structuredClone(createDefaultSave().garage[0]);
+}
+
+function createGarageCar(overrides = {}) {
+  return {
+    ...getStarterCar(),
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // utils.js
@@ -334,7 +338,7 @@ describe("garage.js", () => {
       assert.strictEqual(isGarageSlotFilled(createEmptyGarageSlot(0)), false);
     });
     it("returns true for a car without empty flag", () => {
-      assert.strictEqual(isGarageSlotFilled(STARTER_STATS), true);
+      assert.strictEqual(isGarageSlotFilled(getStarterCar()), true);
     });
     it("returns false for null", () => {
       assert.strictEqual(isGarageSlotFilled(null), false);
@@ -345,10 +349,11 @@ describe("garage.js", () => {
     it("returns 0 for an empty slot", () => {
       assert.strictEqual(getGarageHandling(createEmptyGarageSlot(0)), 0);
     });
-    it("computes correctly for the starter car stats", () => {
-      const handling = getGarageHandling(STARTER_STATS);
-      // ((2.28/2.95)*58) + ((6.58/9.1)*42) ≈ 75.2
-      approx(handling, 75.196, 0.01);
+    it("increases when turn or grip improve and clamps extreme builds", () => {
+      const starter = getStarterCar();
+      assert.ok(getGarageHandling({ ...starter, turn: starter.turn + 0.2 }) > getGarageHandling(starter));
+      assert.ok(getGarageHandling({ ...starter, grip: starter.grip + 0.8 }) > getGarageHandling(starter));
+      assert.strictEqual(getGarageHandling({ ...starter, turn: 999, grip: 999 }), 100);
     });
   });
 
@@ -356,131 +361,146 @@ describe("garage.js", () => {
     it("returns 0 for an empty slot", () => {
       assert.strictEqual(getGarageScore(createEmptyGarageSlot(0)), 0);
     });
-    it("computes the expected score for starter car stats", () => {
-      // Calculated: accel%≈17.3, speed%≈23.1, handling%≈75.2, dur%≈31.25
-      // score = round(0.27*17.3 + 0.27*23.1 + 0.28*75.2 + 0.18*31.25) = 38
-      assert.strictEqual(getGarageScore(STARTER_STATS), 38);
+    it("rewards stronger builds and caps maxed-out stats", () => {
+      const starter = getStarterCar();
+      const accelUpgrade = { ...starter, accel: starter.accel + 40 };
+      const durabilityUpgrade = { ...starter, durability: starter.durability + 20 };
+      const maxed = createGarageCar({
+        accel: 9999,
+        maxSpeed: 9999,
+        turn: 9999,
+        grip: 9999,
+        durability: 9999,
+      });
+      assert.ok(getGarageScore(accelUpgrade) > getGarageScore(starter));
+      assert.ok(getGarageScore(durabilityUpgrade) > getGarageScore(starter));
+      assert.strictEqual(getGarageScore(maxed), 100);
     });
   });
 
   describe("getGarageStatPercent", () => {
     it("returns 0 for an unknown stat id", () => {
-      assert.strictEqual(getGarageStatPercent(STARTER_STATS, "unknown"), 0);
+      assert.strictEqual(getGarageStatPercent(getStarterCar(), "unknown"), 0);
     });
     it("returns a value in [0, 100] for accel", () => {
-      const pct = getGarageStatPercent(STARTER_STATS, "accel");
+      const pct = getGarageStatPercent(getStarterCar(), "accel");
       assert.ok(pct >= 0 && pct <= 100, `${pct} outside [0,100]`);
     });
   });
 
   describe("getScrapValue", () => {
-    const base = GARAGE_SCRAP_VALUE;
-    const car = (tierId, score) => ({ ...STARTER_STATS, tierId, score });
-
-    it("apex tier: adds +22 bonus", () => {
-      // score=38 < 55 so no score bonus
-      assert.strictEqual(getScrapValue(car("apex", 38)), base + 22);
+    it("increases with higher tiers for the same chassis", () => {
+      const baseCar = getStarterCar();
+      const street = getScrapValue({ ...baseCar, tierId: "street" });
+      const club = getScrapValue({ ...baseCar, tierId: "club" });
+      const pro = getScrapValue({ ...baseCar, tierId: "pro" });
+      const apex = getScrapValue({ ...baseCar, tierId: "apex" });
+      assert.ok(street < club);
+      assert.ok(club < pro);
+      assert.ok(pro < apex);
     });
-    it("pro tier: adds +14 bonus", () => {
-      assert.strictEqual(getScrapValue(car("pro", 38)), base + 14);
-    });
-    it("club tier: adds +8 bonus", () => {
-      assert.strictEqual(getScrapValue(car("club", 38)), base + 8);
-    });
-    it("street tier: adds +4 bonus", () => {
-      assert.strictEqual(getScrapValue(car("street", 38)), base + 4);
-    });
-    it("adds score bonus for high-stat car (score well above 55)", () => {
-      // Max-stat car: getGarageScore returns 100.
-      // bonus = Math.max(0, round((100-55)/10)) = round(4.5) = 5
-      const maxCar = { accel: 620, maxSpeed: 430, turn: 3.08, grip: 9.4, durability: 156, tierId: "street" };
-      const result = getScrapValue(maxCar);
-      assert.strictEqual(result, base + 4 + 5);
+    it("adds more scrap for stronger cars within the same tier", () => {
+      const starter = getStarterCar();
+      const low = getScrapValue({ ...starter, tierId: "street" });
+      const high = getScrapValue(createGarageCar({
+        tierId: "street",
+        accel: 9999,
+        maxSpeed: 9999,
+        turn: 9999,
+        grip: 9999,
+        durability: 9999,
+      }));
+      assert.ok(high > low);
     });
   });
 
   describe("calculateRaceReward", () => {
-    it("baseline: non-guided, last place, no goals, over par, 2 destroyed = 92", () => {
-      assert.strictEqual(calculateRaceReward(makeResult()), 92);
+    it("returns a positive integer baseline payout", () => {
+      const reward = calculateRaceReward(makeResult());
+      assert.ok(Number.isInteger(reward));
+      assert.ok(reward > 0);
     });
 
-    it("guided event uses lower base reward", () => {
-      const r = calculateRaceReward(makeResult({ event: { guided: true } }));
-      assert.strictEqual(r, 72);
+    it("guided events pay less base reward than standard events", () => {
+      const standard = calculateRaceReward(makeResult());
+      const guided = calculateRaceReward(makeResult({ event: { guided: true } }));
+      assert.ok(guided < standard);
     });
 
-    it("1st place adds 72", () => {
-      const r = calculateRaceReward(makeResult({ place: 1 }));
-      assert.strictEqual(r, 92 + 72);
+    it("rewards stronger finishing positions", () => {
+      const first = calculateRaceReward(makeResult({ place: 1 }));
+      const second = calculateRaceReward(makeResult({ place: 2 }));
+      const third = calculateRaceReward(makeResult({ place: 3 }));
+      const fourth = calculateRaceReward(makeResult({ place: 4 }));
+      assert.ok(first > second);
+      assert.strictEqual(second, third);
+      assert.ok(third > fourth);
     });
 
-    it("2nd or 3rd place adds 40", () => {
-      assert.strictEqual(calculateRaceReward(makeResult({ place: 2 })), 92 + 40);
-      assert.strictEqual(calculateRaceReward(makeResult({ place: 3 })), 92 + 40);
+    it("adds the same increment for each goal met", () => {
+      const zeroGoals = calculateRaceReward(makeResult({ goalsMet: 0 }));
+      const oneGoal = calculateRaceReward(makeResult({ goalsMet: 1 }));
+      const twoGoals = calculateRaceReward(makeResult({ goalsMet: 2 }));
+      assert.ok(oneGoal > zeroGoals);
+      assert.ok(twoGoals > oneGoal);
+      assert.strictEqual(twoGoals - oneGoal, oneGoal - zeroGoals);
     });
 
-    it("each goal met adds 24", () => {
-      assert.strictEqual(calculateRaceReward(makeResult({ goalsMet: 3 })), 92 + 72);
+    it("rewards beating par time", () => {
+      const overPar = calculateRaceReward(makeResult({ deltaToPar: 5 }));
+      const onPar = calculateRaceReward(makeResult({ deltaToPar: 0 }));
+      const underPar = calculateRaceReward(makeResult({ deltaToPar: -5 }));
+      assert.ok(onPar > overPar);
+      assert.strictEqual(onPar, underPar);
     });
 
-    it("finishing under par (deltaToPar <= 0) adds 26", () => {
-      const r = calculateRaceReward(makeResult({ deltaToPar: 0 }));
-      assert.strictEqual(r, 92 + 26);
+    it("rewards cleaner survival in even steps", () => {
+      const twoWrecks = calculateRaceReward(makeResult({ destroyedCount: 2 }));
+      const oneWreck = calculateRaceReward(makeResult({ destroyedCount: 1 }));
+      const zeroWrecks = calculateRaceReward(makeResult({ destroyedCount: 0 }));
+      assert.ok(zeroWrecks > oneWreck);
+      assert.ok(oneWreck > twoWrecks);
+      assert.strictEqual(zeroWrecks - oneWreck, oneWreck - twoWrecks);
     });
 
-    it("surviving without destruction adds 20; partial survival adds 10", () => {
-      assert.strictEqual(calculateRaceReward(makeResult({ destroyedCount: 0 })), 92 + 20);
-      assert.strictEqual(calculateRaceReward(makeResult({ destroyedCount: 1 })), 92 + 10);
-      assert.strictEqual(calculateRaceReward(makeResult({ destroyedCount: 2 })), 92);
-    });
-
-    it("new event best adds 18 (non-guided only)", () => {
+    it("applies event-best bonuses only to non-guided runs", () => {
       const nonGuided = calculateRaceReward(makeResult({ newEventBest: true }));
-      assert.strictEqual(nonGuided, 92 + 18);
-
+      const nonGuidedBase = calculateRaceReward(makeResult());
       const guided = calculateRaceReward(makeResult({ newEventBest: true, event: { guided: true } }));
-      assert.strictEqual(guided, 72); // no bonus
+      const guidedBase = calculateRaceReward(makeResult({ event: { guided: true } }));
+      assert.ok(nonGuided > nonGuidedBase);
+      assert.strictEqual(guided, guidedBase);
     });
 
-    it("daily event adds 68", () => {
-      const r = calculateRaceReward(makeResult({ event: { daily: true } }));
-      assert.strictEqual(r, 92 + 68);
+    it("adds daily and daily-best bonuses independently", () => {
+      const baseline = calculateRaceReward(makeResult());
+      const daily = calculateRaceReward(makeResult({ event: { daily: true } }));
+      const dailyBest = calculateRaceReward(makeResult({ newDailyBest: true }));
+      const stacked = calculateRaceReward(makeResult({ event: { daily: true }, newDailyBest: true }));
+      assert.ok(daily > baseline);
+      assert.ok(dailyBest > baseline);
+      assert.ok(stacked > daily);
+      assert.ok(stacked > dailyBest);
     });
 
-    it("new daily best adds 36", () => {
-      const r = calculateRaceReward(makeResult({ newDailyBest: true }));
-      assert.strictEqual(r, 92 + 36);
-    });
-
-    it("tutorial pickup adds 48 when both flags set", () => {
-      const r = calculateRaceReward(makeResult({
+    it("only awards the tutorial pickup bonus when both tutorial flags are set", () => {
+      const guidedBase = calculateRaceReward(makeResult({
+        event: { guided: true },
+        wasTutorialRun: true,
+        tutorialPickupMet: false,
+      }));
+      const tutorialMet = calculateRaceReward(makeResult({
         event: { guided: true },
         wasTutorialRun: true,
         tutorialPickupMet: true,
-        destroyedCount: 0,
-        deltaToPar: 0,
       }));
-      // 72 (guided) + 26 (par) + 20 (0 destroyed) + 48 (tutorial)
-      assert.strictEqual(r, 166);
-    });
-
-    it("tutorial pickup not awarded if pickup not met", () => {
-      const r = calculateRaceReward(makeResult({ wasTutorialRun: true, tutorialPickupMet: false }));
-      assert.strictEqual(r, 92);
-    });
-
-    it("maximum combined payout (all bonuses, non-guided daily)", () => {
-      const r = calculateRaceReward(makeResult({
-        place: 1,
-        goalsMet: 3,
-        deltaToPar: -5,
-        destroyedCount: 0,
-        newEventBest: true,
-        newDailyBest: true,
-        event: { guided: false, daily: true },
+      const notTutorialRun = calculateRaceReward(makeResult({
+        event: { guided: true },
+        wasTutorialRun: false,
+        tutorialPickupMet: true,
       }));
-      // 92 + 72 + 72 + 26 + 20 + 18 + 68 + 36 = 404
-      assert.strictEqual(r, 404);
+      assert.ok(tutorialMet > guidedBase);
+      assert.strictEqual(notTutorialRun, guidedBase);
     });
   });
 

--- a/tests/units/generator.test.mjs
+++ b/tests/units/generator.test.mjs
@@ -73,21 +73,32 @@ describe("generator.js", () => {
     it("builds the guided opener without hazards and with a lead shield beacon", () => {
       const track = buildTrack(getEvent("tutorial-ignition"));
       assert.strictEqual(track.hazards.length, 0);
-      assert.strictEqual(track.pickups.length, 7);
+      assert.ok(track.pickups.length > 0);
       assert.strictEqual(track.pickups[0].kind, "shield");
       assert.strictEqual(track.pickups[0].guidedBeacon, true);
-      approx(track.pickups[0].t, 0.052, 1e-9);
+      assert.ok(nearestPathInfo(track, track.pickups[0].x, track.pickups[0].y).distance < 1);
       assert.ok(track.safeRespawnNodes.length > 0);
       assert.ok(track.safeRespawnNodes.every((node) => getSectorAtProgress(track, node.t).tag !== "hazard"));
     });
 
     it("applies pickup and hazard modifiers to generated counts", () => {
-      const densePickupTrack = buildTrack(getEvent("grid-slipstream"));
-      const hazardTrack = buildTrack(getEvent("void-collar"));
-      assert.strictEqual(densePickupTrack.pickups.length, 10);
-      assert.strictEqual(densePickupTrack.hazards.length, 4);
-      assert.strictEqual(hazardTrack.pickups.length, 7);
-      assert.strictEqual(hazardTrack.hazards.length, 7);
+      const densePickupEvent = getEvent("grid-slipstream");
+      const basePickupEvent = getEvent("grid-slipstream");
+      basePickupEvent.modifierIds = [];
+
+      const hazardEvent = getEvent("void-collar");
+      const baseHazardEvent = getEvent("void-collar");
+      baseHazardEvent.modifierIds = baseHazardEvent.modifierIds.filter((id) => id !== "high-damage-hazards");
+
+      const densePickupTrack = buildTrack(densePickupEvent);
+      const basePickupTrack = buildTrack(basePickupEvent);
+      const hazardTrack = buildTrack(hazardEvent);
+      const baseHazardTrack = buildTrack(baseHazardEvent);
+
+      assert.ok(densePickupTrack.pickups.length > basePickupTrack.pickups.length);
+      assert.strictEqual(densePickupTrack.hazards.length, basePickupTrack.hazards.length);
+      assert.ok(hazardTrack.hazards.length > baseHazardTrack.hazards.length);
+      assert.strictEqual(hazardTrack.pickups.length, baseHazardTrack.pickups.length);
     });
 
     it("keeps props outside the road corridor", () => {

--- a/tests/units/race-progress.test.mjs
+++ b/tests/units/race-progress.test.mjs
@@ -1,0 +1,132 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeLeaderboard } from "../../src/core/gameplay.js";
+import { getCarRaceUnits, getTrackRaceUnits } from "../../src/core/raceProgress.js";
+import { createDefaultSave } from "../../src/core/save.js";
+import { buildRunSummary } from "../../src/core/ui.js";
+
+const approx = (actual, expected, epsilon = 1e-9) =>
+  assert.ok(Math.abs(actual - expected) < epsilon, `expected ~${expected}, got ${actual}`);
+
+function createCheckpoint(index, count) {
+  return { index, t: index / count };
+}
+
+describe("raceProgress.js", () => {
+  it("treats car.progress as lap-wide progress units instead of adding checkpoint index again", () => {
+    const state = {
+      track: {
+        type: "circuit",
+        checkpoints: Array.from({ length: 10 }, (_, index) => createCheckpoint(index, 10)),
+      },
+      currentEvent: {
+        laps: 2,
+      },
+    };
+
+    assert.strictEqual(getTrackRaceUnits(state), 20);
+    approx(getCarRaceUnits(state, { currentLap: 1, checkpointIndex: 9, progress: 0.95 }), 9.5);
+    approx(getCarRaceUnits(state, { currentLap: 2, checkpointIndex: 0, progress: 0.02 }), 10.2);
+  });
+
+  it("keeps live ordering and classified gaps on the same track-progress scale", () => {
+    const save = createDefaultSave();
+    const playerId = save.garage[0].id;
+    const state = {
+      track: {
+        type: "circuit",
+        checkpoints: Array.from({ length: 10 }, (_, index) => createCheckpoint(index, 10)),
+      },
+      currentEvent: {
+        id: "circuit-test",
+        name: "Circuit Test",
+        seed: 42,
+        type: "circuit",
+        laps: 2,
+        parTime: 105,
+        daily: false,
+        guided: false,
+        goals: [],
+      },
+      save,
+      selectedCarId: playerId,
+      finishTime: 100,
+      elapsed: 100,
+      runPickupCounts: {},
+    };
+
+    const winner = {
+      id: "winner",
+      label: "Winner",
+      isPlayer: false,
+      currentLap: 2,
+      checkpointIndex: 9,
+      progress: 1,
+      finished: true,
+      finishMs: 100,
+      vx: 0,
+      vy: 0,
+      respawns: 0,
+      wallHits: 0,
+      pickupUses: 0,
+      pulseHits: 0,
+      destroyedCount: 0,
+      lapTimes: [48.5, 51.5],
+      bestLapTime: 48.5,
+      lastLapTime: 51.5,
+    };
+    const player = {
+      id: playerId,
+      label: "You",
+      isPlayer: true,
+      currentLap: 1,
+      checkpointIndex: 9,
+      progress: 0.95,
+      finished: false,
+      finishMs: null,
+      vx: 220,
+      vy: 0,
+      respawns: 0,
+      wallHits: 0,
+      pickupUses: 0,
+      pulseHits: 0,
+      destroyedCount: 0,
+      lapTimes: [49.8],
+      bestLapTime: 49.8,
+      lastLapTime: 49.8,
+    };
+    const rival = {
+      id: "rival-a",
+      label: "Rival A",
+      isPlayer: false,
+      rival: true,
+      currentLap: 2,
+      checkpointIndex: 0,
+      progress: 0.02,
+      finished: false,
+      finishMs: null,
+      vx: 220,
+      vy: 0,
+      respawns: 0,
+      wallHits: 0,
+      pickupUses: 0,
+      pulseHits: 0,
+      destroyedCount: 0,
+      lapTimes: [50.1],
+      bestLapTime: 50.1,
+      lastLapTime: 50.1,
+    };
+
+    state.player = player;
+    state.cars = [winner, player, rival];
+
+    const leaderboard = computeLeaderboard(state);
+    assert.deepStrictEqual(leaderboard.map((car) => car.id), ["winner", "rival-a", playerId]);
+
+    const summary = buildRunSummary(state, leaderboard);
+    assert.strictEqual(summary.classification[1].id, "rival-a");
+    approx(summary.classification[2].intervalToAhead, 3.515, 1e-6);
+    approx(summary.gapToWinner, 52.53, 1e-6);
+  });
+});

--- a/tests/units/ui-routing.test.mjs
+++ b/tests/units/ui-routing.test.mjs
@@ -24,6 +24,10 @@ import {
   renderTags,
 } from "../../src/core/ui/render-helpers.js";
 
+function countMatches(source, pattern) {
+  return [...source.matchAll(pattern)].length;
+}
+
 describe("controls.js", () => {
   it("returns default bindings when no custom key is present", () => {
     assert.strictEqual(getControlBinding({}, "accel"), "w");
@@ -111,24 +115,41 @@ describe("ui sections and routing", () => {
 
 describe("ui render helpers", () => {
   it("renders tags and info buttons", () => {
-    assert.strictEqual(renderTags(["A", "B"]), `<span class="mini-tag">A</span><span class="mini-tag">B</span>`);
-    assert.ok(renderInfoButton("info-1", "More info", "Tooltip body").includes(`data-tooltip="Tooltip body"`));
+    const tags = renderTags(["A", "B"]);
+    assert.strictEqual(countMatches(tags, /class="mini-tag"/g), 2);
+    assert.match(tags, />A<\/span>/);
+    assert.match(tags, />B<\/span>/);
+
+    const infoButton = renderInfoButton("info-1", "More info", "Tooltip body");
+    assert.match(infoButton, /<button[^>]+id="info-1"/);
+    assert.match(infoButton, /class="info-btn"/);
+    assert.match(infoButton, /aria-label="More info"/);
+    assert.match(infoButton, /aria-haspopup="dialog"/);
+    assert.match(infoButton, /aria-expanded="false"/);
+    assert.match(infoButton, /data-tooltip="Tooltip body"/);
   });
 
   it("renders summary grids and empty recent-run copy", () => {
     const summary = renderSummaryGrid([{ label: "Wins", value: "5", note: "Hot streak" }]);
-    assert.ok(summary.includes("Wins"));
-    assert.ok(summary.includes("Hot streak"));
+    assert.strictEqual(countMatches(summary, /class="profile-item profile-item-compact"/g), 1);
+    assert.match(summary, /<div class="section-label">Wins<\/div>/);
+    assert.match(summary, /<div class="profile-value">5<\/div>/);
+    assert.match(summary, /<div class="profile-note">Hot streak<\/div>/);
 
     const emptyRuns = renderRecentRuns([]);
-    assert.ok(emptyRuns.includes("First line"));
-    assert.ok(emptyRuns.includes("Daily push"));
+    assert.strictEqual(countMatches(emptyRuns, /class="results-item"/g), 3);
+    assert.strictEqual(countMatches(emptyRuns, /<strong>/g), 3);
+    assert.strictEqual(countMatches(emptyRuns, /class="results-inline"/g), 3);
   });
 
   it("renders populated recent runs and iso car figures", () => {
     const runs = renderRecentRuns([{ eventName: "Shatterline", place: 2, finishTime: "1:29.50", reward: 140, wrecks: 1 }]);
-    assert.ok(runs.includes("Shatterline"));
-    assert.ok(runs.includes("P2 // 1:29.50 // +140 Flux // 1 wrecks"));
+    assert.strictEqual(countMatches(runs, /class="results-item"/g), 1);
+    assert.match(runs, /<strong>Shatterline<\/strong>/);
+    assert.match(runs, /P2\b/);
+    assert.match(runs, /1:29\.50/);
+    assert.match(runs, /\+140 Flux/);
+    assert.match(runs, /1 wreck/);
 
     const emptyFigure = renderIsoCarFigure(null);
     assert.ok(emptyFigure.includes("No chassis online"));


### PR DESCRIPTION
## Summary
This branch expands the repo's unit-test lane, hardens brittle test assertions, and fixes three gameplay/save regressions uncovered during that work.

The test side of the branch adds focused unit coverage for generator, garage, save, style, routing, isometric, and race-progress helpers, plus a cross-platform unit runner so `npm run validate:units` and the full `npm run validate` wrapper stop depending on shell- or Node-version-specific glob expansion. It also rewrites the most brittle unit checks so they assert durable behavior instead of exact balance totals, literal UI copy fragments, or exact HTML serialization.

The runtime side fixes three user-facing issues. Live race order and results classification were mixing lap-wide `progress` with `checkpointIndex`, which overcounted late-lap cars and understated early next-lap cars. Hub auto-selection could clamp oversized `eventProgress` values into the appended daily event instead of the last strike-board event. Foundry rolls persisted the Flux spend before the roll outcome existed, so reloading mid-reveal could permanently burn currency with no reward.

## Root Cause
The validation lane had grown around implementation details instead of stable contracts in a few places, and the unit runner still relied on test-discovery behavior that differed across environments. That left the suite more fragile than useful when tuning copy, markup, or balance.

The race-ordering bug came from treating normalized track progress as if it were checkpoint-local progress in two separate code paths, so leaderboard ordering and classified gap math drifted in the same way. The event-selection bug came from clamping against `state.events.length - 1`, which includes the daily slot that is appended after the strike board. The Foundry persistence bug came from saving the wallet immediately after purchase while keeping `garageRoll` only in transient runtime state.

## Fix
I added a shared race-progress helper module and routed both gameplay leaderboard scoring and legacy results classification through the same unit conversion, so circuit and sprint progress are compared on one consistent scale. I updated the menu-selection helpers to clamp saved progression to the last non-daily board slot and reused that clamp when advancing progression after wins. I also changed Foundry roll start-up so the save is only persisted when the roll is actually resolved, which means a mid-reveal reload restores the pre-roll wallet instead of leaving the player short on Flux.

On the test side, the branch adds new focused suites for the previously under-covered helper modules, switches the unit scripts to an explicit file enumerator for cross-platform execution, and replaces brittle assertions with checks around structure, invariants, and relative behavior. I also added targeted regressions for race-progress ordering/classification, oversized `eventProgress`, and the mid-roll reload case in the Playwright lane.

## Validation
- `node --test tests/units/race-progress.test.mjs`
- `npx playwright test tests/playwright/validate.spec.mjs --grep "oversized event progress auto-selects the last strike-board event instead of the daily|reloading during a garage roll restores the pre-roll save instead of burning Flux"`
- `npm run validate`
